### PR TITLE
Split provider interface

### DIFF
--- a/src/MessageListenerProxy.php
+++ b/src/MessageListenerProxy.php
@@ -21,7 +21,7 @@ class MessageListenerProxy
     /** @var array */
     protected $registeredMethods = [];
 
-    public function __construct(RegisterableNotificationListenerProvider $provider, string $serviceName, string $serviceClass)
+    public function __construct(RegisterableNotificationListenerProviderInterface $provider, string $serviceName, string $serviceClass)
     {
         $this->provider = $provider;
         $this->serviceName = $serviceName;

--- a/src/MessageListenerProxy.php
+++ b/src/MessageListenerProxy.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+use Fig\EventDispatcher\ParameterDeriverTrait;
+
+class MessageListenerProxy
+{
+    use ParameterDeriverTrait;
+
+    /** @var RegisterableNotificationListenerProvider */
+    protected $provider;
+
+    /** @var string */
+    protected $serviceName;
+
+    /** @var string */
+    protected $serviceClass;
+
+    /** @var array */
+    protected $registeredMethods = [];
+
+    public function __construct(RegisterableNotificationListenerProvider $provider, string $serviceName, string $serviceClass)
+    {
+        $this->provider = $provider;
+        $this->serviceName = $serviceName;
+        $this->serviceClass = $serviceClass;
+    }
+
+    /**
+     * Adds a method on a service as a listener.
+     *
+     * @param string $methodName
+     *   The method name of the service that is the listener being registered.
+     *   The ID of this listener, so it can be referenced by other listeners.
+     * @param string|null $type
+     *   The class or interface type of events for which this listener will be registered.
+     * @return string
+     *   The opaque ID of the listener.  This can be used for future reference.
+     */
+    public function addListener(string $methodName, string $type = null): void
+    {
+        $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        $this->registeredMethods[] = $methodName;
+
+        $this->provider->addListenerService($this->serviceName, $methodName, $type);
+    }
+
+    public function getRegisteredMethods() : array
+    {
+        return $this->registeredMethods;
+    }
+}

--- a/src/MessageSubscriberInterface.php
+++ b/src/MessageSubscriberInterface.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+interface MessageSubscriberInterface
+{
+
+    public static function registerListeners(MessageListenerProxy $proxy) : void;
+}

--- a/src/ProviderBuilder.php
+++ b/src/ProviderBuilder.php
@@ -72,8 +72,8 @@ class ProviderBuilder implements RegisterableProviderInterface, \IteratorAggrega
         $proxy = new ListenerProxy($this, $serviceName, $class);
 
         // Explicit registration is opt-in.
-        if (in_array(SubscriberInterface::class, class_implements($class))) {
-            /** @var SubscriberInterface */
+        if (in_array(TaskSubscriberInterface::class, class_implements($class))) {
+            /** @var TaskSubscriberInterface */
             $class::registerListeners($proxy);
         }
 

--- a/src/ProviderBuilderInterface.php
+++ b/src/ProviderBuilderInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+interface ProviderBuilderInterface extends \IteratorAggregate
+{
+    /**
+     * Returns an iterable of listener entries, in the order they should be called if applicable.
+     *
+     * @return CompileableListenerEntryInterface[]
+     */
+    public function getIterator();
+}

--- a/src/ProviderCompiler.php
+++ b/src/ProviderCompiler.php
@@ -8,7 +8,7 @@ use Crell\Tukio\Entry\CompileableListenerEntryInterface;
 class ProviderCompiler
 {
     /**
-     * @param ProviderBuilder $listeners
+     * @param ProviderBuilderInterface $listeners
      *   The set of listeners to compile.
      * @param resource $stream
      *   A writeable stream to which to write the compiled class.
@@ -17,7 +17,7 @@ class ProviderCompiler
      * @param string $namespace
      *   the namespace for the compiled class.
      */
-    public function compile(ProviderBuilder $listeners, $stream, string $class = 'CompiledListenerProvider', string $namespace = '\\Crell\\Tukio\\Compiled') : void
+    public function compile(ProviderBuilderInterface $listeners, $stream, string $class = 'CompiledListenerProvider', string $namespace = '\\Crell\\Tukio\\Compiled') : void
     {
         fwrite($stream, $this->createPreamble($class, $namespace));
 

--- a/src/RegisterableNotificationListenerProvider.php
+++ b/src/RegisterableNotificationListenerProvider.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
-class RegisterableNotificationListenerProvider implements ListenerProviderInterface
+class RegisterableNotificationListenerProvider implements ListenerProviderInterface, RegisterableNotificationListenerProviderInterface
 {
     use ProviderUtilitiesTrait;
 

--- a/src/RegisterableNotificationListenerProviderInterface.php
+++ b/src/RegisterableNotificationListenerProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+interface RegisterableNotificationListenerProviderInterface
+{
+    public function addListener(callable $listener, string $type = null): void;
+
+    public function addListenerService(string $serviceName, string $methodName, string $type): void;
+
+    public function addSubscriber(string $class, string $serviceName): void;
+}

--- a/src/TaskSubscriberInterface.php
+++ b/src/TaskSubscriberInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Crell\Tukio;
 
-interface SubscriberInterface
+interface TaskSubscriberInterface
 {
 
     public static function registerListeners(ListenerProxy $proxy) : void;

--- a/tests/CompiledListenerProviderTest.php
+++ b/tests/CompiledListenerProviderTest.php
@@ -20,7 +20,7 @@ function listenerB(CollectingTask $event) : void
 /**
  * @throws \Exception
  */
-function noListen(EventOne $event) : void
+function noListen(TaskOne $event) : void
 {
     throw new \Exception('This should not be called');
 }
@@ -89,10 +89,10 @@ class CompiledEventDispatcherTest extends TestCase
 
         $builder = new ProviderBuilder();
         $container = new MockContainer();
-        $subscriber = new MockSubscriber();
+        $subscriber = new MockTaskSubscriber();
 
         $container->addService('subscriber', $subscriber);
-        $builder->addSubscriber(MockSubscriber::class, 'subscriber');
+        $builder->addSubscriber(MockTaskSubscriber::class, 'subscriber');
 
         $provider = $this->makeProvider($builder, $container, $class, $namespace);
 

--- a/tests/CompiledMessageListenerProviderTest.php
+++ b/tests/CompiledMessageListenerProviderTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+function notifyListenerA(MessageOne $event) : void
+{
+    CompiledMessageEventDispatcherTest::$results[] = 'A';
+}
+
+function notifyListenerB(MessageOne $event) : void
+{
+    CompiledMessageEventDispatcherTest::$results[] = 'B';
+}
+
+/**
+ * @throws \Exception
+ */
+function notifierNoListen(MessageTwo $event) : void
+{
+    throw new \Exception('This should not be called');
+}
+
+class NotificationListen
+{
+    public static function listen(MessageOne $event)
+    {
+        CompiledMessageEventDispatcherTest::$results[] = 'C';
+    }
+}
+
+class NotificationListenService
+{
+
+    public static function listen(MessageOne $event)
+    {
+        CompiledMessageEventDispatcherTest::$results[] = 'D';
+    }
+}
+
+class CompiledMessageEventDispatcherTest extends TestCase
+{
+    use MakeCompiledProviderTrait;
+
+    public static $results = [];
+
+    public function setUp()
+    {
+        parent::setUp();
+        static::$results = [];
+    }
+
+    function test_compiled_provider_triggers()
+    {
+        $class = 'CompiledProvider';
+        $namespace = 'Test\\Notifier';
+
+        $builder = new NotificationProviderBuilder();
+
+        $container = new MockContainer();
+        $container->addService('D', new NotificationListenService());
+
+        $builder->addListener('\\Crell\\Tukio\\notifyListenerA');
+        $builder->addListener('\\Crell\\Tukio\\notifyListenerB');
+        $builder->addListener('\\Crell\\Tukio\\notifierNoListen');
+        $builder->addListener([NotificationListen::class, 'listen']);
+        $builder->addListenerService('D', 'listen', MessageOne::class);
+
+        $provider = $this->makeProvider($builder, $container, $class, $namespace);
+
+        $event = new MessageOne();
+        foreach ($provider->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $expected = ['A', 'B', 'C', 'D'];
+        $res = static::$results;
+        sort($res);
+        $this->assertEquals($expected, $res);
+    }
+
+    public function test_add_subscriber()
+    {
+        // This test is parallel to and uses the same mock subscriber as
+        // RegisterableListenerProviderServiceTest::test_add_subscriber().
+        // Thus if both work it means the same subscriber works the same
+        // transparently in both compiled and non-compiled versions.
+
+        $class = 'SubscriberProvider';
+        $namespace = 'Test\\Notification';
+
+        $builder = new NotificationProviderBuilder();
+        $container = new MockContainer();
+        $subscriber = new MockMessageSubscriber();
+
+        $container->addService('subscriber', $subscriber);
+        $builder->addSubscriber(MockMessageSubscriber::class, 'subscriber');
+
+        $provider = $this->makeProvider($builder, $container, $class, $namespace);
+
+        $event = new MessageOne();
+        foreach ($provider->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $expected = ['A', 'B', 'C', 'D', 'E', 'F'];
+        $res = $subscriber->results;
+        sort($res);
+        $this->assertEquals($expected, $res);
+    }
+
+}

--- a/tests/MakeCompiledProviderTrait.php
+++ b/tests/MakeCompiledProviderTrait.php
@@ -15,7 +15,7 @@ trait MakeCompiledProviderTrait
      * Technically this is the core of every test in this class.  However, the build process
      * is identical in all cases so there's little point in repeating the code.
      *
-     * @param ProviderBuilder $builder
+     * @param ProviderBuilderInterface $builder
      *   A builder, ready to compile.
      * @param ContainerInterface $container
      *   A container to provide to the built provider.
@@ -26,7 +26,7 @@ trait MakeCompiledProviderTrait
      * @return ListenerProviderInterface
      *   The compiled provider.
      */
-    protected function makeProvider(ProviderBuilder $builder, ContainerInterface $container, string $class, string $namespace) : ListenerProviderInterface
+    protected function makeProvider(ProviderBuilderInterface $builder, ContainerInterface $container, string $class, string $namespace) : ListenerProviderInterface
     {
         try {
             $compiler = new ProviderCompiler();

--- a/tests/MockMessageSubscriber.php
+++ b/tests/MockMessageSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+
+class MockMessageSubscriber implements MessageSubscriberInterface
+{
+    public $results = [];
+
+    public function onA(MessageOne $event) : void
+    {
+        $this->results[] = 'A';
+    }
+    public function onB(MessageOne $event) : void
+    {
+        $this->results[] = 'B';
+    }
+    public function onC(MessageOne $event) : void
+    {
+        $this->results[] = 'C';
+    }
+    public function onD(MessageOne $event) : void
+    {
+        $this->results[] = 'D';
+    }
+    public function onE(MessageOne $event) : void
+    {
+        $this->results[] = 'E';
+    }
+
+    public function notNormalName(MessageOne $message) : void
+    {
+        $this->results[] = 'F';
+    }
+
+    public function onG(NoMessage $message) : void
+    {
+        $this->results[] = 'G';
+    }
+
+    public function ignoredMethodThatDoesNothing() : void
+    {
+        throw new \Exception('What are you doing here?');
+    }
+
+    public static function registerListeners(MessageListenerProxy $proxy): void
+    {
+        $proxy->addListener('onA');
+        $proxy->addListener('onB');
+        $proxy->addListener('onC');
+        $proxy->addListener('onD');
+        // Don't register E.  It should self-register by reflection.
+        $proxy->addListener('notNormalName');
+        $proxy->addListener('onG');
+    }
+}
+

--- a/tests/MockTaskSubscriber.php
+++ b/tests/MockTaskSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Crell\Tukio;
 
 
-class MockSubscriber implements SubscriberInterface
+class MockTaskSubscriber implements TaskSubscriberInterface
 {
     public function onA(CollectingTask $event) : void
     {

--- a/tests/Notification/CompiledMessageListenerProviderInheritanceTest.php
+++ b/tests/Notification/CompiledMessageListenerProviderInheritanceTest.php
@@ -1,0 +1,153 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Notification;
+
+use Crell\Tukio\MakeCompiledProviderTrait;
+use Crell\Tukio\MockContainer;
+use Crell\Tukio\NotificationProviderBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventInterface;
+
+interface EventParentInterface extends EventInterface
+{
+    public function add(string $val) : void;
+    public function result() : array;
+}
+
+class ListenedDirectly implements EventParentInterface {
+    protected $out = [];
+
+    public function add(string $val) : void
+    {
+        $this->out[] = $val;
+    }
+
+    public function result() : array
+    {
+        return $this->out;
+    }
+}
+
+class Subclass extends ListenedDirectly {}
+
+class NotListenedDirectly implements EventParentInterface {
+    protected $out = [];
+
+    public function add(string $val) : void
+    {
+        $this->out[] = $val;
+    }
+
+    public function result() : array
+    {
+        return $this->out;
+    }
+}
+
+function inheritanceListenerA(EventParentInterface $event) : void
+{
+    $event->add('A');
+}
+
+function inheritanceListenerB(ListenedDirectly $event) : void
+{
+    $event->add('B');
+}
+
+function inheritanceListenerC(Subclass $event) : void
+{
+    $event->add('C');
+}
+
+
+class CompiledMessageListenerProviderInheritanceTest extends TestCase
+{
+    use MakeCompiledProviderTrait;
+
+    protected $compiledNamespace = 'Test\\Notification';
+
+    public function test_interface_listener_catches_everything() : void
+    {
+        $class = __FUNCTION__;
+
+        $builder = new NotificationProviderBuilder();
+        $container = new MockContainer();
+
+        $ns = __NAMESPACE__;
+        $builder->addListener("{$ns}\\inheritanceListenerA");
+
+        $provider = $this->makeProvider($builder, $container, $class, $this->compiledNamespace);
+
+        $tests = [
+            ListenedDirectly::class => 'A',
+            Subclass::class => 'A',
+            NotListenedDirectly::class => 'A',
+        ];
+
+        foreach ($tests as $class => $result) {
+            /** @var EventParentInterface $event */
+            $event = new $class();
+            foreach ($provider->getListenersForEvent($event) as $listener) {
+                $listener($event);
+            }
+            $this->assertEquals($result, implode($event->result()));
+        }
+    }
+
+    public function test_class_listener_catches_subclass() : void
+    {
+        $class = __FUNCTION__;
+
+        $builder = new NotificationProviderBuilder();
+        $container = new MockContainer();
+
+        $ns = __NAMESPACE__;
+        $builder->addListener("{$ns}\inheritanceListenerB");
+
+        $provider = $this->makeProvider($builder, $container, $class, $this->compiledNamespace);
+
+        $tests = [
+            ListenedDirectly::class => 'B',
+            Subclass::class => 'B',
+            NotListenedDirectly::class => '',
+        ];
+
+        foreach ($tests as $class => $result) {
+            /** @var EventParentInterface $event */
+            $event = new $class();
+            foreach ($provider->getListenersForEvent($event) as $listener) {
+                $listener($event);
+            }
+            $this->assertEquals($result, implode($event->result()));
+        }
+    }
+
+    public function test_subclass_listener_catches_subclass() : void
+    {
+        $class = __FUNCTION__;
+
+        $builder = new NotificationProviderBuilder();
+        $container = new MockContainer();
+
+        $ns = __NAMESPACE__;
+        $builder->addListener("{$ns}\inheritanceListenerC");
+
+        $provider = $this->makeProvider($builder, $container, $class, $this->compiledNamespace);
+
+        $tests = [
+            ListenedDirectly::class => '',
+            Subclass::class => 'C',
+            NotListenedDirectly::class => '',
+        ];
+
+        foreach ($tests as $class => $result) {
+            /** @var EventParentInterface $event */
+            $event = new $class();
+            foreach ($provider->getListenersForEvent($event) as $listener) {
+                $listener($event);
+            }
+            $this->assertEquals($result, implode($event->result()));
+        }
+    }
+}

--- a/tests/RegisterableListenerProviderServiceTest.php
+++ b/tests/RegisterableListenerProviderServiceTest.php
@@ -134,13 +134,13 @@ class RegisterableListenerProviderServiceTest extends TestCase
     {
         $container = new MockContainer();
 
-        $subscriber = new MockSubscriber();
+        $subscriber = new MockTaskSubscriber();
 
         $container->addService('subscriber', $subscriber);
 
         $p = new RegisterableListenerProvider($container);
 
-        $p->addSubscriber(MockSubscriber::class, 'subscriber');
+        $p->addSubscriber(MockTaskSubscriber::class, 'subscriber');
 
         $event = new CollectingTask();
 

--- a/tests/RegisterableListenerProviderTest.php
+++ b/tests/RegisterableListenerProviderTest.php
@@ -6,9 +6,9 @@ namespace Crell\Tukio;
 
 use PHPUnit\Framework\TestCase;
 
-class EventOne extends CollectingTask {}
+class TaskOne extends CollectingTask {}
 
-class EventTwo extends CollectingTask {}
+class TaskTwo extends CollectingTask {}
 
 class RegisterableListenerProviderTest extends TestCase
 {
@@ -16,13 +16,13 @@ class RegisterableListenerProviderTest extends TestCase
     {
         $p = new RegisterableListenerProvider();
 
-        $p->addListener(function (EventOne $event) {
+        $p->addListener(function (TaskOne $event) {
             $event->add('Y');
         });
         $p->addListener(function (CollectingTask $event) {
             $event->add('Y');
         });
-        $p->addListener(function (EventTwo $event) {
+        $p->addListener(function (TaskTwo $event) {
             $event->add('N');
         });
         // This class doesn't exist but should not result in an error.
@@ -30,7 +30,7 @@ class RegisterableListenerProviderTest extends TestCase
             $event->add('F');
         });
 
-        $event = new EventOne();
+        $event = new TaskOne();
 
         foreach ($p->getListenersForEvent($event) as $listener) {
             $listener($event);

--- a/tests/RegisterableNotificationListenerProviderTest.php
+++ b/tests/RegisterableNotificationListenerProviderTest.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\MessageInterface;
+
+// These need to extend from MessageInterface, but that means changing a lot more of the test.
+class MessageOne implements MessageInterface {}
+
+class MessageTwo implements MessageInterface {}
+
+class RegisterableNotificationListenerProviderTest extends TestCase
+{
+
+    /** @var MockContainer */
+    protected $mockContainer;
+
+    /** @var array */
+    protected $results;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $container = new MockContainer();
+
+        $results = [];
+        $this->results = &$results;
+
+        foreach (['A', 'B', 'C', 'R', 'E'] as $name) {
+            $container->addService($name, new class($results, $name)
+            {
+                protected $results;
+                protected $name;
+                public function __construct(&$results, $name)
+                {
+                    $this->results = &$results;
+                    $this->name = $name;
+                }
+
+                public function listen(MessageInterface $event)
+                {
+                    $this->results[] = $this->name;
+                }
+            });
+        }
+
+        $container->addService('L', new class($results)
+        {
+            protected $results;
+            public function __construct(&$results)
+            {
+                $this->results = &$results;
+            }
+
+            public function hear(MessageInterface $event)
+            {
+                $this->results[] = 'L';
+            }
+        });
+
+        $this->mockContainer = $container;
+    }
+
+    public function test_only_type_correct_listeners_are_returned(): void
+    {
+        $p = new RegisterableNotificationListenerProvider();
+
+        $results = [];
+
+        $p->addListener(function (MessageOne $event) use (&$results) {
+            $results[] = 'Y';
+        });
+        $p->addListener(function (MessageInterface $event) use (&$results) {
+            $results[] = 'Y';
+        });
+        $p->addListener(function (MessageTwo $event) use (&$results) {
+            $results[] = 'N';
+        });
+        // This class doesn't exist but should not result in an error.
+        $p->addListener(function (NoEvent $event) use (&$results) {
+            $results[] = 'F';
+        });
+
+        $event = new MessageOne();
+
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $this->assertEquals('YY', implode($results));
+    }
+
+
+    public function test_add_listener_service(): void
+    {
+        $p = new RegisterableNotificationListenerProvider($this->mockContainer);
+
+        $p->addListenerService('L', 'hear', MessageInterface::class);
+        $p->addListenerService('E', 'listen', MessageInterface::class);
+        $p->addListenerService('C', 'listen', MessageInterface::class);
+        $p->addListenerService('L', 'hear', MessageInterface::class);
+        $p->addListenerService('R', 'listen', MessageInterface::class);
+
+        $event = new MessageOne();
+
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $expected = ['C', 'R', 'E', 'L', 'L'];
+        sort($expected);
+        $res = $this->results;
+        sort($res);
+        $this->assertEquals($expected, $res);
+    }
+
+    public function test_service_registration_fails_without_container(): void
+    {
+        $this->expectException(ContainerMissingException::class);
+
+        $p = new RegisterableNotificationListenerProvider();
+
+        $p->addListenerService('L', 'hear', MessageInterface::class);
+    }
+
+    public function test_add_subscriber() : void
+    {
+        $container = new MockContainer();
+
+        $subscriber = new MockMessageSubscriber();
+
+        $container->addService('subscriber', $subscriber);
+
+        $p = new RegisterableNotificationListenerProvider($container);
+
+        $p->addSubscriber(MockMessageSubscriber::class, 'subscriber');
+
+        $event = new MessageOne();
+
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $expected = ['A', 'B', 'C', 'D', 'E', 'F'];
+        $res = $subscriber->results;
+        sort($res);
+        $this->assertEquals($expected, $res);
+    }
+
+}


### PR DESCRIPTION
An example of what the implications would be of splitting the provider into two separate interfaces.

A number of the classes involved here are tests, so the change is not, necessarily, quite as large as it looks.  However, it is still extremely large.

* I count 6 new classes and interfaces in src alone, all of which are 95% duplication.
* There's 4 new test classes.  While not needed at runtime, it does show that making sure that both provider pipelines continue to work is, well, double the effort.
* Most of the duplication comes from one of 2 places:
** The interface is different, thus the type hint has to be different.
** The notification version has fewer parameters, because it doesn't have to consider ordering.  However, the presence of ordering has no affect on the notification version.  That is, even if users are able to control the order, that has no importance on the spec, by design.  That is, there's no actual benefit over using the same provider and just ignoring those parameters.
** It may be possible to simplify a bit further by factoring some code out to base classes or traits, but both of those feel like code smells.

The purported benefits of splitting the provider interface are:
1) We don't have to come up with a new name for "Event" if we rename Task to Event.
2) Users can have more targeted providers for each pipeline, since no listener will ever apply to both object types, which can be more performant.
3) It's confusing to have a single provider for 2 different things.

For points 2 and 3, that is trivially resolved by simply instantiating the provider twice.  There is absolutely nothing in the spec (when the provider is not split) that forces an implementer to use the same provider object for both cases.  That solves the performance question completely without any changes.

Nor is there anything that requires an implementer to have only one implementation; with a single interface it is still absolutely spec-legal to have two separate provider implementations, with different internal capabilities.  Or they can use the same provider implementation.  That's entirely up to the implementer to work out as they find most useful.  By forcing it to be 2 separate interfaces, however, it becomes impossible to combine any part of the supporting code in a meaningful way.

(This can also be further clarified in the spec or meta-document.)

In fact, it would be super simple to implement a `BasicProvider` object that is essentially the `RegisterableNotificationListenerProvider` shown here and offer it as an alternative.  Users/implementers could use either one in either case.  (Say, if they want Tasks but don't care about order.)  But by using the same interface, 2/3 of the code duplication shown here goes away.

In short, I see many, many downsides to forcing two separate interfaces and only marginal benefit: That we can rename Task to Event without having to come up with a new name for the generic case.  I find that extremely uncompelling.  At this point in the process, if we want to s/Task/Event/ I would say the onus is on those arguing to do so to come up with an alternative name. :smile: The net effect of avoiding it is substantially negative.