### PR TITLE
Workflow demonstration

### DIFF
--- a/src/DelegatingProvider.php
+++ b/src/DelegatingProvider.php
@@ -7,6 +7,20 @@ namespace Crell\Tukio;
 use Psr\EventDispatcher\EventInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
+/**
+ * A Delegating provider.
+ *
+ * The delegating provider allows for selected types of event to be handled by dedicated
+ * sub-providers, which if used will block the use of a default sub-provider.  That is,
+ * certain high-frequency event types (mainly some Tasks) can be handled by dedicated
+ * providers and then skip the normal lookup process of the default provider.  That can
+ * provide a performance benefit if certain tasks are triggered many dozens of times
+ * or more.
+ *
+ * Note: The presence of a sub-provider that wants to intercept a given type of event
+ * will be sufficient to block the default from firing, even if it has no applicable
+ * listeners.
+ */
 class DelegatingProvider implements ListenerProviderInterface
 {
 

--- a/src/DelegatingProvider.php
+++ b/src/DelegatingProvider.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+
+use Psr\EventDispatcher\EventInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class DelegatingProvider implements ListenerProviderInterface
+{
+
+    /**
+     * @var array
+     *
+     * An array of type to provider maps.  The keys are class name strings.
+     * The values are an array of provider objects that should be called for that type.
+     */
+    protected $providers =[];
+
+    /** @var ListenerProviderInterface */
+    protected $defaultProvider;
+
+    public function addProvider(ListenerProviderInterface $provider, array $types) : self
+    {
+        foreach ($types as $type) {
+            $this->providers[$type][] = $provider;
+        }
+
+        return $this;
+    }
+
+    public function setDefaultProvider(ListenerProviderInterface $provider) : self
+    {
+        $this->defaultProvider = $provider;
+
+        return $this;
+    }
+
+    public function getListenersForEvent(EventInterface $event): iterable
+    {
+        $found = false;
+        foreach ($this->providers as $type => $providers) {
+            if ($event instanceof $type) {
+                /** @var ListenerProviderInterface $provider */
+                foreach ($providers as $provider) {
+                    $found = true;
+                    yield from $provider->getListenersForEvent($event);
+                }
+            }
+        }
+
+        if (!$found) {
+            yield from $this->defaultProvider->getListenersForEvent($event);
+        }
+    }
+}

--- a/tests/DelegatingProviderTest.php
+++ b/tests/DelegatingProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class DelegatingProviderTest extends TestCase
+{
+
+    public function test_dedicated_provider_blocks_default() : void
+    {
+        $specific = new class implements ListenerProviderInterface {
+            public function getListenersForEvent(EventInterface $event): iterable
+            {
+                yield function (CollectingTask $event) { $event->add('A'); };
+            }
+        };
+        $default = new class implements ListenerProviderInterface {
+            public function getListenersForEvent(EventInterface $event): iterable
+            {
+                yield function (CollectingTask $event) { $event->add('B'); };
+            }
+        };
+
+        $p = new DelegatingProvider();
+        $p->setDefaultProvider($default);
+        $p->addProvider($specific, [CollectingTask::class]);
+
+        $event = new CollectingTask();
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+        $this->assertEquals('A', implode($event->result()));
+    }
+
+    public function test_dedicated_provider_unused_goes_to_default() : void
+    {
+        $specific = new class implements ListenerProviderInterface {
+            public function getListenersForEvent(EventInterface $event): iterable
+            {
+                return [];
+            }
+        };
+        $default = new class implements ListenerProviderInterface {
+            public function getListenersForEvent(EventInterface $event): iterable
+            {
+                yield function (CollectingTask $event) { $event->add('B'); };
+            }
+        };
+
+        $p = new DelegatingProvider();
+        $p->setDefaultProvider($default);
+        $p->addProvider($specific, [DoesNotExist::class]);
+
+        $event = new CollectingTask();
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+        $this->assertEquals('B', implode($event->result()));
+    }
+
+
+}

--- a/tests/Workflow/WorkflowEndTask.php
+++ b/tests/Workflow/WorkflowEndTask.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Workflow;
+
+class WorkflowEndTask extends WorkflowTask
+{
+
+}

--- a/tests/Workflow/WorkflowProvider.php
+++ b/tests/Workflow/WorkflowProvider.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Workflow;
+
+use Fig\EventDispatcher\ParameterDeriverTrait;
+use Psr\EventDispatcher\EventInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+class WorkflowProvider implements ListenerProviderInterface
+{
+    use ParameterDeriverTrait;
+
+    /** @var array */
+    protected $listeners = [];
+
+    public function getListenersForEvent(EventInterface $event) : iterable
+    {
+        if (!$event instanceof WorkflowTaskInterface) {
+            return [];
+        }
+
+        /** WorkflowTaskInterface $event */
+        $name = $event->workflowName();
+
+        foreach ($this->listeners[$name] as $type => $listeners) {
+            foreach ($listeners as $listener) {
+                if ($event instanceof $type) {
+                    yield $listener;
+                }
+            }
+        }
+    }
+
+    public function addListener(callable $listener, string $workflowName, string $type = null) : void
+    {
+        $type = $type ?? $this->getParameterType($listener);
+
+        $this->listeners[$workflowName][$type][] = $listener;
+    }
+
+}

--- a/tests/Workflow/WorkflowProvider.php
+++ b/tests/Workflow/WorkflowProvider.php
@@ -14,6 +14,9 @@ class WorkflowProvider implements ListenerProviderInterface
     /** @var array */
     protected $listeners = [];
 
+    /** @var array */
+    protected $all = [];
+
     public function getListenersForEvent(EventInterface $event) : iterable
     {
         if (!$event instanceof WorkflowTaskInterface) {
@@ -30,13 +33,25 @@ class WorkflowProvider implements ListenerProviderInterface
                 }
             }
         }
+        foreach ($this->all as $type => $listeners) {
+            foreach ($listeners as $listener) {
+                if ($event instanceof $type) {
+                    yield $listener;
+                }
+            }
+        }
     }
 
-    public function addListener(callable $listener, string $workflowName, string $type = null) : void
+    public function addListener(callable $listener, string $workflowName = '', string $type = null) : void
     {
         $type = $type ?? $this->getParameterType($listener);
 
-        $this->listeners[$workflowName][$type][] = $listener;
+        if ($workflowName) {
+            $this->listeners[$workflowName][$type][] = $listener;
+        }
+        else {
+            $this->all[$type][] = $listener;
+        }
     }
 
 }

--- a/tests/Workflow/WorkflowProviderTest.php
+++ b/tests/Workflow/WorkflowProviderTest.php
@@ -30,18 +30,22 @@ class WorkflowProviderTest extends TestCase
     {
         $p = new WorkflowProvider();
 
+        // This has the right workflow name and event type.
         $p->addListener(function (WorkflowStartTask $task) {
             $task->add('A');
         }, 'bob');
 
+        // This has the wrong workflow type.
         $p->addListener(function (WorkflowEndTask $task) {
             $task->add('B');
         }, 'bob');
 
+        // This matches the parent, so would be called for both WorkflowStart and WorkflowEnd.
         $p->addListener(function (WorkflowTask $task) {
             $task->add('C');
         }, 'bob');
 
+        // This is the right type but the wrong workflow name, so it won't be called.
         $p->addListener(function (WorkflowStartTask $task) {
             $task->add('D');
         }, 'anita');

--- a/tests/Workflow/WorkflowProviderTest.php
+++ b/tests/Workflow/WorkflowProviderTest.php
@@ -50,12 +50,17 @@ class WorkflowProviderTest extends TestCase
             $task->add('D');
         }, 'anita');
 
+        // This is the right type and applies to any workflow name.
+        $p->addListener(function (WorkflowStartTask $task) {
+            $task->add('E');
+        });
+
         $event = new WorkflowStartTask('bob');
 
         foreach ($p->getListenersForEvent($event) as $listener) {
             $listener($event);
         }
 
-        $this->assertEquals('AC', implode($event->result()));
+        $this->assertEquals('ACE', implode($event->result()));
     }
 }

--- a/tests/Workflow/WorkflowProviderTest.php
+++ b/tests/Workflow/WorkflowProviderTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Workflow;
+
+use Crell\Tukio\CollectingTask;
+use PHPUnit\Framework\TestCase;
+
+class WorkflowProviderTest extends TestCase
+{
+
+    public function test_non_workflow_events_ignored() : void
+    {
+        $p = new WorkflowProvider();
+
+        $p->addListener(function (WorkflowStartTask $task) {
+            $task->add('A');
+        }, 'bob');
+
+        $event = new CollectingTask();
+
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $this->assertEmpty($event->result());
+    }
+
+    public function test_workflow_event_called_for_own_name_only() : void
+    {
+        $p = new WorkflowProvider();
+
+        $p->addListener(function (WorkflowStartTask $task) {
+            $task->add('A');
+        }, 'bob');
+
+        $p->addListener(function (WorkflowEndTask $task) {
+            $task->add('B');
+        }, 'bob');
+
+        $p->addListener(function (WorkflowTask $task) {
+            $task->add('C');
+        }, 'bob');
+
+        $p->addListener(function (WorkflowStartTask $task) {
+            $task->add('D');
+        }, 'anita');
+
+        $event = new WorkflowStartTask('bob');
+
+        foreach ($p->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $this->assertEquals('AC', implode($event->result()));
+    }
+}

--- a/tests/Workflow/WorkflowStartTask.php
+++ b/tests/Workflow/WorkflowStartTask.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Workflow;
+
+class WorkflowStartTask extends WorkflowTask
+{
+
+}

--- a/tests/Workflow/WorkflowTask.php
+++ b/tests/Workflow/WorkflowTask.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Workflow;
+
+use Crell\Tukio\CollectingTask;
+
+class WorkflowTask extends CollectingTask implements WorkflowTaskInterface
+{
+    /** @var string */
+    protected $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function workflowName(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Workflow/WorkflowTaskInterface.php
+++ b/tests/Workflow/WorkflowTaskInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio\Workflow;
+
+use Psr\EventDispatcher\TaskInterface;
+
+interface WorkflowTaskInterface extends TaskInterface
+{
+
+    public function workflowName() : string;
+
+}


### PR DESCRIPTION
This is a simple demonstration of how listeners could be registered that care about more than just the event type.  In this case we show off how to register a workflow name, which is an arbitrary string.  I have omitted ordering for now as it's not relevant to this demonstration.

As shown in the test (see line 33 of WorkflowProviderTest), this allows us to register listeners for 

A) A workflow event and name.
C) All workflow events for a given workflow name.
E) All workflow events of any type for any workflow.

The C and E cases would be difficult or impossible to do if the event were identified by a string only, unless the string were non-opaque and had to be parsed internally.  (Say, a format like `workflow.start.bob`, and some provider knew to break it up at the periods and that each segment meant something specific.)  That would require either defining a parsing algorithm that all implementers MUST follow (which sounds like a terrible idea) or allowing the string to be meaningful to only certain provider implementations.  However, that opens the door for collision and confusion; if a workflow library used the string format defined above, and were run in the same environment as another library that had another, incompatible format... what happens?  I don't know, but it's probably not pretty.

It might be possible to sort out that confusion with careful string parsing and informal conventions, but 1) String parsing is slow and the devil and 2) Replacing informal conventions with formal ones is the whole point of PSRs.

The DelegatingProvider is included as a demonstration of how such a workflow-specific provider could be slotted into a larger workflow; register it as the provider for `WorkflowTaskInterface`, and it gets used instead for those while anything else falls through to the default provider.  Then the DelegatingProvider can be passed to the TaskProcessor, and the entire system can sill have a single entry point to task processing, workflow or otherwise.  (Or not; you can have a separate instance if TaskProcessor if you want, that's cool.)