### PR TITLE
Fix subscriber method name registration.

### DIFF
--- a/src/OrderedListenerProvider.php
+++ b/src/OrderedListenerProvider.php
@@ -128,7 +128,7 @@ class OrderedListenerProvider implements ListenerProviderInterface, OrderedProvi
             /** @var \ReflectionMethod $rMethod */
             foreach ($methods as $rMethod) {
                 $methodName = $rMethod->getName();
-                if (!in_array($methodName, $proxy->getRegisteredMethods()) && strpos($methodName, 'on') !== false) {
+                if (!in_array($methodName, $proxy->getRegisteredMethods()) && strpos($methodName, 'on') === 0) {
                     $params = $rMethod->getParameters();
                     $type = $params[0]->getType()->getName();
                     $this->addListenerService($serviceName, $rMethod->getName(), $type);

--- a/src/ProviderBuilder.php
+++ b/src/ProviderBuilder.php
@@ -84,7 +84,7 @@ class ProviderBuilder implements OrderedProviderInterface, \IteratorAggregate
             /** @var \ReflectionMethod $rMethod */
             foreach ($methods as $rMethod) {
                 $methodName = $rMethod->getName();
-                if (!in_array($methodName, $proxy->getRegisteredMethods()) && strpos($methodName, 'on') !== false) {
+                if (!in_array($methodName, $proxy->getRegisteredMethods()) && strpos($methodName, 'on') === 0) {
                     $params = $rMethod->getParameters();
                     $type = $params[0]->getType()->getName();
                     $this->addListenerService($serviceName, $rMethod->getName(), $type);

--- a/tests/MockSubscriber.php
+++ b/tests/MockSubscriber.php
@@ -42,6 +42,11 @@ class MockSubscriber implements SubscriberInterface
         throw new \Exception('What are you doing here?');
     }
 
+    public function ignoredMethodWithOnInTheName_on() : void
+    {
+        throw new \Exception('What are you doing here?');
+    }
+
     public static function registerListeners(ListenerProxy $proxy): void
     {
         $a = $proxy->addListener('onA');


### PR DESCRIPTION
Fixes the issue raised [here.](https://github.com/Crell/Tukio/issues/7)

Updated subscriber registration to require the 'on' in 'onSomething' to occur only at the start of the method name, such that (as an example) onEvent is caught, but handleJson is ignored.

This was tested by updating the `MockSubscriber` test class to include a method that should be ignored, but has 'on' later in the name. It yields 2 testing errors on master, and none after the updates from this PR.