### PR TITLE
Add type errors to OrderedListenerProvider

### DIFF
--- a/src/InvalidTypeException.php
+++ b/src/InvalidTypeException.php
@@ -6,32 +6,35 @@ namespace Crell\Tukio;
 use \ReflectionClass;
 use \ReflectionFunction;
 use \ReflectionException;
+use \Throwable;
 
 class InvalidTypeException extends \RuntimeException
 {
-    protected $message = 'Function does not specify a valid type';
+    protected static $baseMessage = 'Function does not specify a valid type';
 
-    public function setMessageFromClass($class, string $method)
+    public static function fromClassCallable($class, string $method, ?Throwable $previous = null)
     {
+        $message = static::$baseMessage;
         try {
             $reflector = new ReflectionClass($class);
-            $this->message .= " (".$reflector->getName()."::$method)";
+            $message .= " (".$reflector->getName()."::$method)";
         } catch (ReflectionException $e) {
-            $this->message .= " ((unknown class)::$method)";
+            $message .= " ((unknown class)::$method)";
         }
-        return $this;
+        return new static($message, 0, $previous);
     }
-
-    public function setMessageFromFunction(callable $function)
+    
+    public static function fromFunctionCallable(callable $function, ?Throwable $previous = null)
     {
+        $message = static::$baseMessage;
         if (is_string($function) || $function instanceof \Closure) {
             try {
                 $reflector = new ReflectionFunction($function);
-                $this->message .= " (".$reflector->getFileName().":".$reflector->getStartLine().")";
+                $message .= " (".$reflector->getFileName().":".$reflector->getStartLine().")";
             } catch (ReflectionException $e) {
                 // No meaningful data to add
             }
         }
-        return $this;
+        return new static($message, 0, $previous);
     }
 }

--- a/src/InvalidTypeException.php
+++ b/src/InvalidTypeException.php
@@ -17,7 +17,7 @@ class InvalidTypeException extends \RuntimeException
         $message = static::$baseMessage;
         try {
             $reflector = new ReflectionClass($class);
-            $message .= " (".$reflector->getName()."::$method)";
+            $message .= " (" . $reflector->getName() . "::$method)";
         } catch (ReflectionException $e) {
             $message .= " ((unknown class)::$method)";
         }
@@ -30,7 +30,7 @@ class InvalidTypeException extends \RuntimeException
         if (is_string($function) || $function instanceof \Closure) {
             try {
                 $reflector = new ReflectionFunction($function);
-                $message .= " (".$reflector->getFileName().":".$reflector->getStartLine().")";
+                $message .= " (" . $reflector->getFileName() . ":" . $reflector->getStartLine() . ")";
             } catch (ReflectionException $e) {
                 // No meaningful data to add
             }

--- a/src/InvalidTypeException.php
+++ b/src/InvalidTypeException.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+use \ReflectionClass;
+use \ReflectionFunction;
+use \ReflectionException;
+
+class InvalidTypeException extends \RuntimeException
+{
+    protected $message = 'Function does not specify a valid type';
+
+    public function setMessageFromClass($class, string $method)
+    {
+        try {
+            $reflector = new ReflectionClass($class);
+            $this->message .= " (".$reflector->getName()."::$method)";
+        } catch (ReflectionException $e) {
+            $this->message .= " ((unknown class)::$method)";
+        }
+        return $this;
+    }
+
+    public function setMessageFromFunction(callable $function)
+    {
+        if (is_string($function) || $function instanceof \Closure) {
+            try {
+                $reflector = new ReflectionFunction($function);
+                $this->message .= " (".$reflector->getFileName().":".$reflector->getStartLine().")";
+            } catch (ReflectionException $e) {
+                // No meaningful data to add
+            }
+        }
+        return $this;
+    }
+}

--- a/src/ListenerProxy.php
+++ b/src/ListenerProxy.php
@@ -46,8 +46,8 @@ class ListenerProxy
     {
         try {
             $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
-        } catch (\InvalidArgumentException $e) {
-            throw (new InvalidTypeException())->setMessageFromClass($this->serviceClass, $methodName);
+        } catch (\InvalidArgumentException $exception) {
+            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
         }
         $this->registeredMethods[] = $methodName;
 
@@ -75,8 +75,8 @@ class ListenerProxy
     {
         try {
             $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
-        } catch (\InvalidArgumentException $e) {
-            throw (new InvalidTypeException())->setMessageFromClass($this->serviceClass, $methodName);
+        } catch (\InvalidArgumentException $exception) {
+            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
         }
         $this->registeredMethods[] = $methodName;
 
@@ -104,8 +104,8 @@ class ListenerProxy
     {
         try {
             $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
-        } catch (\InvalidArgumentException $e) {
-            throw (new InvalidTypeException())->setMessageFromClass($this->serviceClass, $methodName);
+        } catch (\InvalidArgumentException $exception) {
+            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
         }
         $this->registeredMethods[] = $methodName;
 

--- a/src/ListenerProxy.php
+++ b/src/ListenerProxy.php
@@ -44,7 +44,11 @@ class ListenerProxy
      */
     public function addListener(string $methodName, int $priority = 0, string $id = null, string $type = null): string
     {
-        $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        try {
+            $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        } catch (\InvalidArgumentException $e) {
+            throw (new InvalidTypeException())->setMessageFromClass($this->serviceClass, $methodName);
+        }
         $this->registeredMethods[] = $methodName;
 
         return $this->provider->addListenerService($this->serviceName, $methodName, $type, $priority, $id);
@@ -69,7 +73,11 @@ class ListenerProxy
      */
     public function addListenerBefore(string $pivotId, string $methodName, string $id = null, string $type = null): string
     {
-        $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        try {
+            $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        } catch (\InvalidArgumentException $e) {
+            throw (new InvalidTypeException())->setMessageFromClass($this->serviceClass, $methodName);
+        }
         $this->registeredMethods[] = $methodName;
 
         return $this->provider->addListenerServiceBefore($pivotId, $this->serviceName, $methodName, $type, $id);
@@ -94,7 +102,11 @@ class ListenerProxy
      */
     public function addListenerAfter(string $pivotId, string $methodName, string $id = null, string $type = null) : string
     {
-        $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        try {
+            $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
+        } catch (\InvalidArgumentException $e) {
+            throw (new InvalidTypeException())->setMessageFromClass($this->serviceClass, $methodName);
+        }
         $this->registeredMethods[] = $methodName;
 
         return $this->provider->addListenerServiceAfter($pivotId, $this->serviceName, $methodName, $type, $id);

--- a/src/ListenerProxy.php
+++ b/src/ListenerProxy.php
@@ -66,12 +66,8 @@ class ListenerProxy
      * @return string
      *   The opaque ID of the listener.  This can be used for future reference.
      */
-    public function addListenerBefore(
-        string $pivotId,
-        string $methodName,
-        string $id = null,
-        string $type = null
-    ): string {
+    public function addListenerBefore(string $pivotId, string $methodName, string $id = null, string $type = null): string
+    {
         $type = $type ?? $this->getServiceMethodType($methodName);
         $this->registeredMethods[] = $methodName;
         return $this->provider->addListenerServiceBefore($pivotId, $this->serviceName, $methodName, $type, $id);
@@ -94,12 +90,8 @@ class ListenerProxy
      * @return string
      *   The opaque ID of the listener.  This can be used for future reference.
      */
-    public function addListenerAfter(
-        string $pivotId,
-        string $methodName,
-        string $id = null,
-        string $type = null
-    ) : string {
+    public function addListenerAfter(string $pivotId, string $methodName, string $id = null, string $type = null) : string
+    {
         $type = $type ?? $this->getServiceMethodType($methodName);
         $this->registeredMethods[] = $methodName;
         return $this->provider->addListenerServiceAfter($pivotId, $this->serviceName, $methodName, $type, $id);

--- a/src/ListenerProxy.php
+++ b/src/ListenerProxy.php
@@ -44,13 +44,8 @@ class ListenerProxy
      */
     public function addListener(string $methodName, int $priority = 0, string $id = null, string $type = null): string
     {
-        try {
-            $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
-        } catch (\InvalidArgumentException $exception) {
-            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
-        }
+        $type = $type ?? $this->getServiceMethodType($methodName);
         $this->registeredMethods[] = $methodName;
-
         return $this->provider->addListenerService($this->serviceName, $methodName, $type, $priority, $id);
     }
 
@@ -71,15 +66,14 @@ class ListenerProxy
      * @return string
      *   The opaque ID of the listener.  This can be used for future reference.
      */
-    public function addListenerBefore(string $pivotId, string $methodName, string $id = null, string $type = null): string
-    {
-        try {
-            $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
-        } catch (\InvalidArgumentException $exception) {
-            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
-        }
+    public function addListenerBefore(
+        string $pivotId,
+        string $methodName,
+        string $id = null,
+        string $type = null
+    ): string {
+        $type = $type ?? $this->getServiceMethodType($methodName);
         $this->registeredMethods[] = $methodName;
-
         return $this->provider->addListenerServiceBefore($pivotId, $this->serviceName, $methodName, $type, $id);
     }
 
@@ -100,20 +94,39 @@ class ListenerProxy
      * @return string
      *   The opaque ID of the listener.  This can be used for future reference.
      */
-    public function addListenerAfter(string $pivotId, string $methodName, string $id = null, string $type = null) : string
-    {
-        try {
-            $type = $type ?? $this->getParameterType([$this->serviceClass, $methodName]);
-        } catch (\InvalidArgumentException $exception) {
-            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
-        }
+    public function addListenerAfter(
+        string $pivotId,
+        string $methodName,
+        string $id = null,
+        string $type = null
+    ) : string {
+        $type = $type ?? $this->getServiceMethodType($methodName);
         $this->registeredMethods[] = $methodName;
-
         return $this->provider->addListenerServiceAfter($pivotId, $this->serviceName, $methodName, $type, $id);
     }
 
     public function getRegisteredMethods() : array
     {
         return $this->registeredMethods;
+    }
+
+    /**
+     * Safely gets the required Type for a given method from the service class.
+     *
+     * @param string $methodName
+     *   The method name of the listener being registered.
+     * @return string
+     *   The type required by the listener.
+     * @throws InvalidTypeException
+     *   If the method has invalid type-hinting, throws an error with a service/method trace.
+     */
+    protected function getServiceMethodType(string $methodName) : string
+    {
+        try {
+            $type = $this->getParameterType([$this->serviceClass, $methodName]);
+        } catch (\InvalidArgumentException $exception) {
+            throw InvalidTypeException::fromClassCallable($this->serviceClass, $methodName, $exception);
+        }
+        return $type;
     }
 }

--- a/src/OrderedListenerProvider.php
+++ b/src/OrderedListenerProvider.php
@@ -41,7 +41,9 @@ class OrderedListenerProvider implements ListenerProviderInterface, OrderedProvi
 
     /**
      * Tries to get the type of a callable listener.
+     *
      * If unable, throws an exception with information about the listener whose type could not be fetched.
+     *
      * @param callable $listener
      * @return string
      */

--- a/src/OrderedListenerProvider.php
+++ b/src/OrderedListenerProvider.php
@@ -45,7 +45,7 @@ class OrderedListenerProvider implements ListenerProviderInterface, OrderedProvi
      * @param callable $listener
      * @return string
      */
-    private function getType(callable $listener)
+    protected function getType(callable $listener)
     {
         try {
             $type = $this->getParameterType($listener);

--- a/src/OrderedListenerProvider.php
+++ b/src/OrderedListenerProvider.php
@@ -49,14 +49,14 @@ class OrderedListenerProvider implements ListenerProviderInterface, OrderedProvi
     {
         try {
             $type = $this->getParameterType($listener);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $exception) {
             if ($this->isClassCallable($listener) || $this->isObjectCallable($listener)) {
-                throw (new InvalidTypeException())->setMessageFromClass($listener[0], $listener[1]);
+                throw InvalidTypeException::fromClassCallable($listener[0], $listener[1], $exception);
             }
             if ($this->isFunctionCallable($listener) || $this->isClosureCallable($listener)) {
-                throw (new InvalidTypeException())->setMessageFromFunction($listener);
+                throw InvalidTypeException::fromFunctionCallable($listener, $exception);
             }
-            throw new InvalidTypeException();
+            throw new InvalidTypeException($exception);
         }
         return $type;
     }
@@ -154,7 +154,7 @@ class OrderedListenerProvider implements ListenerProviderInterface, OrderedProvi
                     $params = $rMethod->getParameters();
                     $type = $params[0]->getType();
                     if (is_null($type)) {
-                        throw (new InvalidTypeException())->setMessageFromClass($class, $rMethod->getName());
+                        throw InvalidTypeException::fromClassCallable($class, $rMethod->getName());
                     }
                     $this->addListenerService($serviceName, $rMethod->getName(), $type->getName());
                 }

--- a/tests/MockMalformedSubscriber.php
+++ b/tests/MockMalformedSubscriber.php
@@ -6,7 +6,7 @@ namespace Crell\Tukio;
 class MockMalformedSubscriber
 {
     /**
-     * This funcion should succeed in automatic registration.
+     * This function should succeed in automatic registration.
      */
     public function onA(CollectingEvent $event) : void
     {

--- a/tests/MockMalformedSubscriber.php
+++ b/tests/MockMalformedSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+class MockMalformedSubscriber
+{
+    /**
+     * This funcion should succeed in automatic registration.
+     */
+    public function onA(CollectingEvent $event) : void
+    {
+        $event->add('A');
+    }
+    /**
+     * This function should have automatic registration attempted, and fail due to missing a type.
+     */
+    public function onNone($event) : void
+    {
+        $event->add('A');
+    }
+    /**
+     * This function should have manual registration attempted, and fail due to missing a type.
+     */
+    public function abnormalNameWithoutType($event) : void
+    {
+        $event->add('B');
+    }
+
+    public static function registerListenersDirect(ListenerProxy $proxy): void
+    {
+        $a = $proxy->addListener('onA');
+        // Should fail and throw an exception:
+        $proxy->addListener('abnormalNameWithoutType');
+    }
+    public static function registerListenersBefore(ListenerProxy $proxy): void
+    {
+        $a = $proxy->addListener('onA');
+        // Should fail and throw an exception:
+        $proxy->addListenerBefore($a, 'abnormalNameWithoutType');
+    }
+    public static function registerListenersAfter(ListenerProxy $proxy): void
+    {
+        $a = $proxy->addListener('onA');
+        // Should fail and throw an exception:
+        $proxy->addListenerAfter($a, 'abnormalNameWithoutType');
+    }
+}

--- a/tests/OrderedListenerProviderServiceTest.php
+++ b/tests/OrderedListenerProviderServiceTest.php
@@ -151,4 +151,69 @@ class OrderedListenerProviderServiceTest extends TestCase
         $this->assertEquals('BCAEDF', implode($event->result()));
     }
 
+    public function test_malformed_subscriber_automatic_fails(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $container = new MockContainer();
+
+        $subscriber = new MockMalformedSubscriber();
+
+        $container->addService('subscriber', $subscriber);
+
+        $p = new OrderedListenerProvider($container);
+
+        $p->addSubscriber(MockMalformedSubscriber::class, 'subscriber');
+    }
+
+    public function test_malformed_subscriber_manual_fails(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $container = new MockContainer();
+
+        $subscriber = new MockMalformedSubscriber();
+
+        $container->addService('subscriber', $subscriber);
+
+        $provider = new OrderedListenerProvider($container);
+
+        $proxy = new ListenerProxy($provider, 'subscriber', MockMalformedSubscriber::class);
+
+        MockMalformedSubscriber::registerListenersDirect($proxy);
+    }
+
+    public function test_malformed_subscriber_manual_before_fails(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $container = new MockContainer();
+
+        $subscriber = new MockMalformedSubscriber();
+
+        $container->addService('subscriber', $subscriber);
+
+        $provider = new OrderedListenerProvider($container);
+
+        $proxy = new ListenerProxy($provider, 'subscriber', MockMalformedSubscriber::class);
+
+        MockMalformedSubscriber::registerListenersBefore($proxy);
+    }
+
+    public function test_malformed_subscriber_manual_after_fails(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $container = new MockContainer();
+
+        $subscriber = new MockMalformedSubscriber();
+
+        $container->addService('subscriber', $subscriber);
+
+        $provider = new OrderedListenerProvider($container);
+
+        $proxy = new ListenerProxy($provider, 'subscriber', MockMalformedSubscriber::class);
+
+        MockMalformedSubscriber::registerListenersAfter($proxy);
+    }
 }

--- a/tests/OrderedListenerProviderTest.php
+++ b/tests/OrderedListenerProviderTest.php
@@ -125,4 +125,43 @@ class OrderedListenerProviderTest extends TestCase
 
         $this->assertEquals('CRELL', implode($event->result()));
     }
+
+    public function test_add_malformed_listener(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $p = new OrderedListenerProvider();
+
+        $p->addListener(function ($event) {
+            $event->add('A');
+        });
+    }
+
+    public function test_add_malformed_listener_before(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $p = new OrderedListenerProvider();
+
+        $a = $p->addListener(function (CollectingEvent $event) {
+            $event->add('A');
+        });
+        $p->addListenerBefore($a, function ($event) {
+            $event->add('B');
+        });
+    }
+
+    public function test_add_malformed_listener_after(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+
+        $p = new OrderedListenerProvider();
+
+        $a = $p->addListener(function (CollectingEvent $event) {
+            $event->add('A');
+        });
+        $p->addListenerAfter($a, function ($event) {
+            $event->add('B');
+        });
+    }
 }


### PR DESCRIPTION
Adds an exception type to facilitate type-related errors, integrates it into the OrderedListenerProvider, and provides tests for its functionality.

## Description

The new Exception type (InvalidTypeException) supports verbose source information, aiding in tracking down listener problems. For example, where formerly an error would either be Fatal or the vague InvalidArgumentException "Listeners must declare an object type they can accept.", we now receive 
`Function does not specify a valid type (<qualified\class>::<method>)`
for class methods, or
`Function does not specify a valid type (<path>\<filename>:<line>)`
for standalone or anonymous functions.

## Motivation and context

Facilitating listener registration with more meaningful errors. See discussion [here.](https://github.com/Crell/Tukio/issues/7)

## Concerns

All locations that now throw InvalidTypeExceptions either used to throw an InvalidArgumentException or threw Fatal errors. Per discussion [here,](https://github.com/Crell/Tukio/issues/7) changing exception types is considered non-breaking in this context, but it's worth noting that use cases designed specifically around catching InvalidArgumentExceptions during registration may experience changed behavior.

## Testing

The new Exception type has test coverage anywhere it is invoked, covering automatic service registration, manual service registration, and manual listener registration.