### PR TITLE
Add Event Dispatcher PSR in "provide" section of the Composer schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "phpbench/phpbench": "@dev",
         "phpunit/phpunit": "~7.0"
     },
+    "provide": {
+        "psr/event-dispatcher-implementation": "1.0"
+    },
     "autoload": {
         "psr-4": {
             "Crell\\Tukio\\": "src"


### PR DESCRIPTION
As described in [Composer documentation], the "provide" section allows 
to define which other packages are provided by this library.

The Event Dispatcher PSR has been added in this section, it will for 
instance add more visibility for this package on [Packagist page].  

[Composer documentation]: https://getcomposer.org/doc/04-schema.md#provide
[Packagist page]: https://packagist.org/providers/psr/event-dispatcher-implementation
