### PR TITLE
Compatibility with psr/log 2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
         "fig/event-dispatcher-util": "^1.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",

--- a/tests/DebugEventDispatcherTest.php
+++ b/tests/DebugEventDispatcherTest.php
@@ -24,7 +24,7 @@ class DebugEventDispatcherTest extends TestCase
         $this->logger = new class extends AbstractLogger {
             public $messages = [];
 
-            public function log($level, $message, array $context = [])
+            public function log($level, $message, array $context = []): void
             {
                 $this->messages[$level][] = [
                     'message' => $message,

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -23,7 +23,7 @@ class DispatcherTest extends TestCase
         $this->logger = new class extends AbstractLogger {
             public $messages = [];
 
-            public function log($level, $message, array $context = [])
+            public function log($level, $message, array $context = []): void
             {
                 $this->messages[$level][] = [
                     'message' => $message,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provides compatibility with psr/log v2.0 and v3.0

## Motivation and context

This will allow Tukio to be used alongside libraries that require psr/log v2.0 and/or v3.0.

## How has this been tested?

I think CI tries to install stable and lowest dependancies.

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
