### PR TITLE
Add support for PHP 8.1, and remove support for 7.2 and 7.3

### DIFF
--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,11 +10,11 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '7.2', '7.3', '7.4', '8.0' ]
+                php: [ '7.3', '7.4', '8.0', '8.1' ]
                 composer-flags: [ '' ]
                 phpunit-flags: [ '--coverage-text' ]
                 include:
-                    - php: '8.0'
+                    - php: '8.1'
                       composer-flags: '--prefer-lowest'
                       phpunit-flags: '--coverage-text'
         steps:

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ 7.4', '8.0', '8.1' ]
+                php: [ '7.4', '8.0', '8.1' ]
                 composer-flags: [ '' ]
                 phpunit-flags: [ '--coverage-text' ]
                 include:

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '7.3', '7.4', '8.0', '8.1' ]
+                php: [ 7.4', '8.0', '8.1' ]
                 composer-flags: [ '' ]
                 phpunit-flags: [ '--coverage-text' ]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "~7.2 | ~8.0",
+        "php": "~7.3 || ~8.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
         "fig/event-dispatcher-util": "^1.0",
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",
-        "phpunit/phpunit": "~8.0"
+        "phpunit/phpunit": "^9.5"
     },
     "provide": {
         "psr/event-dispatcher-implementation": "1.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "~7.3 || ~8.0",
+        "php": "~7.4 || ~8.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/event-dispatcher": "^1.0",
         "fig/event-dispatcher-util": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+  <testsuites>
+    <testsuite name="Tukio Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
   <coverage>
     <include>
       <directory suffix=".php">src/</directory>
@@ -10,11 +26,6 @@
       <text outputFile="build/coverage.txt"/>
     </report>
   </coverage>
-  <testsuites>
-    <testsuite name="Tukio Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Tukio Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Tukio Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/OrderedCollection/OrderedCollection.php
+++ b/src/OrderedCollection/OrderedCollection.php
@@ -146,7 +146,7 @@ class OrderedCollection implements \IteratorAggregate
      * if calling it on the return from this object.  If not, only the last list's worth of values will be included in
      * the resulting array.
      */
-    public function getIterator(): iterable
+    public function getIterator(): \Traversable
     {
         if (!$this->sorted) {
             $this->prioritizePendingItems();

--- a/src/ProviderBuilder.php
+++ b/src/ProviderBuilder.php
@@ -142,7 +142,7 @@ class ProviderBuilder implements OrderedProviderInterface, \IteratorAggregate
         }
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         yield from $this->listeners;
     }


### PR DESCRIPTION
## Description

Add support for PHP 8.1, and remove support for PHP 7.2 and 7.3.

Dropping 7.2 support is the easiest way to upgrade to PHPUnit 9.5 which supports `>=7.3` and also `8.1`. Older version of PHPUnit 8.x does [access the $GLOBALS which is no longer supported in PHP 8.1](https://php.watch/versions/8.1/GLOBALS-restrictions).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
