### PR TITLE
Opt-in optimization for the compiled provider

### DIFF
--- a/benchmarks/CompiledProviderBench.php
+++ b/benchmarks/CompiledProviderBench.php
@@ -47,9 +47,7 @@ class CompiledProviderBench extends ProviderBenchBase
             $priority->next();
         }
 
-        foreach (static::$optimizeClasses as $class) {
-            $builder->optimizeEvent($class);
-        }
+        $builder->optimizeEvents(...static::$optimizeClasses);
 
         // Write the generated compiler out to a temp file.
         $out = fopen(static::$filename, 'w');

--- a/benchmarks/OptimizedCompiledProviderBench.php
+++ b/benchmarks/OptimizedCompiledProviderBench.php
@@ -5,67 +5,13 @@ declare(strict_types=1);
 namespace Crell\Tukio\Benchmarks;
 
 use Crell\Tukio\CollectingEvent;
-use Crell\Tukio\MockContainer;
-use Crell\Tukio\ProviderBuilder;
-use Crell\Tukio\ProviderCompiler;
-use PhpBench\Benchmark\Metadata\Annotations\AfterClassMethods;
-use PhpBench\Benchmark\Metadata\Annotations\BeforeClassMethods;
+use Crell\Tukio\DummyEvent;
 use PhpBench\Benchmark\Metadata\Annotations\Groups;
-use PhpBench\Benchmark\Metadata\Annotations\Iterations;
-use PhpBench\Benchmark\Metadata\Annotations\OutputTimeUnit;
-use PhpBench\Benchmark\Metadata\Annotations\RetryThreshold;
-use PhpBench\Benchmark\Metadata\Annotations\Revs;
-use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 
 /**
  * @Groups({"Providers"})
- * @BeforeClassMethods({"createCompiledProvider"})
- * @AfterClassMethods({"removeCompiledProvider"})
  */
-class OptimizedCompiledProviderBench extends ProviderBenchBase
+class OptimizedCompiledProviderBench extends CompiledProviderBench
 {
-    /** @var string */
-    protected static $filename = 'compiled_provider.php';
-
-    /** @var string */
-    protected static $className = 'CompiledProvider';
-
-    /** @var string */
-    protected static $namespace = 'Test\\Space';
-
-    public static function createCompiledProvider(): void
-    {
-        $builder = new ProviderBuilder();
-        $compiler = new ProviderCompiler();
-
-        $priority = new \InfiniteIterator(new \ArrayIterator(static::$listenerPriorities));
-        $priority->next();
-
-        foreach(range(1, static::$numListeners) as $counter) {
-            $builder->addListener([static::class, 'fakeListener'], $priority->current());
-            $priority->next();
-        }
-
-        $builder->optimizeEvent(CollectingEvent::class);
-
-        // Write the generated compiler out to a temp file.
-        $out = fopen(static::$filename, 'w');
-        $compiler->compile($builder, $out, static::$className, static::$namespace);
-        fclose($out);
-    }
-
-    public static function removeCompiledProvider(): void
-    {
-        //unlink(static::$filename);
-    }
-
-    public function setUp(): void
-    {
-        include static::$filename;
-
-        $container = new MockContainer();
-
-        $compiledClassName = static::$namespace . '\\' . static::$className;
-        $this->provider = new $compiledClassName($container);
-    }
+    protected static array $optimizeClasses = [CollectingEvent::class, DummyEvent::class];
 }

--- a/benchmarks/OptimizedCompiledProviderBench.php
+++ b/benchmarks/OptimizedCompiledProviderBench.php
@@ -22,7 +22,7 @@ use PhpBench\Benchmark\Metadata\Annotations\Warmup;
  * @BeforeClassMethods({"createCompiledProvider"})
  * @AfterClassMethods({"removeCompiledProvider"})
  */
-class CompiledProviderBench extends ProviderBenchBase
+class OptimizedCompiledProviderBench extends ProviderBenchBase
 {
     /** @var string */
     protected static $filename = 'compiled_provider.php';
@@ -45,6 +45,8 @@ class CompiledProviderBench extends ProviderBenchBase
             $builder->addListener([static::class, 'fakeListener'], $priority->current());
             $priority->next();
         }
+
+        $builder->optimizeEvent(CollectingEvent::class);
 
         // Write the generated compiler out to a temp file.
         $out = fopen(static::$filename, 'w');

--- a/benchmarks/OrderedProviderBench.php
+++ b/benchmarks/OrderedProviderBench.php
@@ -14,11 +14,6 @@ use Psr\EventDispatcher\ListenerProviderInterface;
  */
 class OrderedProviderBench extends ProviderBenchBase
 {
-    /**
-     * @var ListenerProviderInterface
-     */
-    protected $provider;
-
     public function setUp(): void
     {
         $this->provider = new OrderedListenerProvider();
@@ -27,7 +22,7 @@ class OrderedProviderBench extends ProviderBenchBase
         $priority->next();
 
         foreach(range(1, static::$numListeners) as $counter) {
-            $this->provider->addListener(static function(CollectingEvent $task): void {}, $priority->current());
+            $this->provider->addListener([static::class, 'fakeListener'], $priority->current());
             $priority->next();
         }
     }

--- a/benchmarks/ProviderBenchBase.php
+++ b/benchmarks/ProviderBenchBase.php
@@ -7,23 +7,25 @@ namespace Crell\Tukio\Benchmarks;
 use Crell\Tukio\CollectingEvent;
 use PhpBench\Benchmark\Metadata\Annotations\Groups;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\OutputTimeUnit;
+use PhpBench\Benchmark\Metadata\Annotations\RetryThreshold;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
 /**
  * @Groups({"Providers"})
- * @Revs(1000)
- * @Iterations(5)
+ * @Revs(50)
+ * @Iterations(10)
+ * @Warmup(2)
+ * @OutputTimeUnit("milliseconds", precision=4)
+ * @RetryThreshold(10.0)
  */
 abstract class ProviderBenchBase extends TukioBenchmarks
 {
-    /**
-     * @var ListenerProviderInterface
-     */
-    protected $provider;
+    protected ListenerProviderInterface $provider;
 
-    /** @var int */
-    protected static $numListeners = 5000;
+    protected static int $numListeners = 1000;
 
     /**
      * @var array<int>
@@ -47,6 +49,10 @@ abstract class ProviderBenchBase extends TukioBenchmarks
         $listeners = $this->provider->getListenersForEvent($task);
 
         // Run out the generator.
-        iterator_to_array($listeners);
+        is_array($listeners) || iterator_to_array($listeners);
+    }
+
+    public static function fakeListener(CollectingEvent $task): void
+    {
     }
 }

--- a/docker/php/74/Dockerfile
+++ b/docker/php/74/Dockerfile
@@ -1,10 +1,8 @@
-FROM php:7.4.28-cli
+FROM php:7.4-cli
 WORKDIR /usr/src/myapp
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update && apt-get install zip unzip git -y \
     && pecl install xdebug \
-    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-    && php composer-setup.php --install-dir=/usr/bin --filename=composer \
-    && php -r "unlink('composer-setup.php');" \
-    && mkdir /.composer && chmod 777 /.composer
+    && pecl install pcov

--- a/docker/php/74/xdebug.ini
+++ b/docker/php/74/xdebug.ini
@@ -1,2 +1,2 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20210902/xdebug.so
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so
 xdebug.output_dir=profiles

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,13 +1,7 @@
 {
-    "bootstrap": "vendor/autoload.php",
-    "path": "benchmarks",
-    "retry_threshold": 5,
-    "reports": {
-        "short": {
-            "title": "Short summary",
-            "extends": "aggregate",
-            "cols": ["benchmark", "subject", "mode", "mean", "stdev", "rstdev", "mem_peak"],
-            "break": ["benchmark"]
-        }
-    }
+    "runner.path": "benchmarks",
+    "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.php_disable_ini": true,
+    "runner.file_pattern": "*Bench.php"
 }

--- a/src/CompiledListenerProviderBase.php
+++ b/src/CompiledListenerProviderBase.php
@@ -21,6 +21,8 @@ class CompiledListenerProviderBase implements ListenerProviderInterface
     /** @var array<mixed> */
     protected const LISTENERS = [];
 
+    protected const OPTIMIZED = [];
+
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -31,30 +33,36 @@ class CompiledListenerProviderBase implements ListenerProviderInterface
      */
     public function getListenersForEvent(object $event): iterable
     {
+        if (isset(static::OPTIMIZED[$event::class])) {
+            return array_map(fn(array $listener) => $this->makeListener($listener), static::OPTIMIZED[$event::class]);
+        }
+
         $count = count(static::LISTENERS);
         $ret = [];
         for ($i = 0; $i < $count; ++$i) {
             /** @var array<mixed> $listener */
             $listener = static::LISTENERS[$i];
             if ($event instanceof $listener['type']) {
-                // Turn this into a match() in PHP 8.
-                switch ($listener['entryType']) {
-                    case ListenerFunctionEntry::class:
-                        $ret[] = $listener['listener'];
-                        break;
-                    case ListenerStaticMethodEntry::class:
-                        $ret[] = [$listener['class'], $listener['method']];
-                        break;
-                    case ListenerServiceEntry::class:
-                        $ret[] = function (object $event) use ($listener): void {
-                            $this->container->get($listener['serviceName'])->{$listener['method']}($event);
-                        };
-                        break;
-                    default:
-                        throw new \RuntimeException(sprintf('No such listener type found in compiled container definition: %s', $listener['entryType']));
-                }
+                $ret[] = $this->makeListener($listener);
             }
         }
         return $ret;
+    }
+
+    protected function makeListener(array $listener): callable
+    {
+        // Turn this into a match() in PHP 8.
+        switch ($listener['entryType']) {
+            case ListenerFunctionEntry::class:
+                return $listener['listener'];
+            case ListenerStaticMethodEntry::class:
+                return [$listener['class'], $listener['method']];
+            case ListenerServiceEntry::class:
+                return function (object $event) use ($listener): void {
+                    $this->container->get($listener['serviceName'])->{$listener['method']}($event);
+                };
+            default:
+                throw new \RuntimeException(sprintf('No such listener type found in compiled container definition: %s', $listener['entryType']));
+        }
     }
 }

--- a/src/CompiledListenerProviderBase.php
+++ b/src/CompiledListenerProviderBase.php
@@ -18,6 +18,7 @@ class CompiledListenerProviderBase implements ListenerProviderInterface
     /** @var array<mixed> */
     protected array $listeners = [];
 
+    /** @var array<class-string, mixed>  */
     protected array $optimized = [];
 
     public function __construct(ContainerInterface $container)

--- a/src/CompiledListenerProviderBase.php
+++ b/src/CompiledListenerProviderBase.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Crell\Tukio;
 
-use Crell\Tukio\Entry\ListenerFunctionEntry;
-use Crell\Tukio\Entry\ListenerServiceEntry;
-use Crell\Tukio\Entry\ListenerStaticMethodEntry;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 
@@ -19,9 +16,9 @@ class CompiledListenerProviderBase implements ListenerProviderInterface
     // entry types in the classes seen in getListenerForEvent().  See each class's getProperties() method for the
     // exact structure.
     /** @var array<mixed> */
-    protected const LISTENERS = [];
+    protected array $listeners = [];
 
-    protected const OPTIMIZED = [];
+    protected array $optimized = [];
 
     public function __construct(ContainerInterface $container)
     {
@@ -33,55 +30,17 @@ class CompiledListenerProviderBase implements ListenerProviderInterface
      */
     public function getListenersForEvent(object $event): iterable
     {
-        if (isset(static::OPTIMIZED[$event::class])) {
-            $count = count(static::OPTIMIZED[$event::class]);
-            $ret = [];
-            for ($i = 0; $i < $count; ++$i) {
-                $listener = static::OPTIMIZED[$event::class];
-                if ($event instanceof $listener['type']) {
-                    // Turn this into a match() in PHP 8.
-                    switch ($listener['entryType']) {
-                        case ListenerFunctionEntry::class:
-                            $ret[] = $listener['listener'];
-                            break;
-                        case ListenerStaticMethodEntry::class:
-                            $ret[] = [$listener['class'], $listener['method']];
-                            break;
-                        case ListenerServiceEntry::class:
-                            $ret[] = function (object $event) use ($listener): void {
-                                $this->container->get($listener['serviceName'])->{$listener['method']}($event);
-                            };
-                            break;
-                        default:
-                            throw new \RuntimeException(sprintf('No such listener type found in compiled container definition: %s', $listener['entryType']));
-                    }
-                }
-            }
-            return $ret;
+        if (isset($this->optimized[$event::class])) {
+            return $this->optimized[$event::class];
         }
 
-        $count = count(static::LISTENERS);
+        $count = count($this->listeners);
         $ret = [];
         for ($i = 0; $i < $count; ++$i) {
             /** @var array<mixed> $listener */
-            $listener = static::LISTENERS[$i];
+            $listener = $this->listeners[$i];
             if ($event instanceof $listener['type']) {
-                // Turn this into a match() in PHP 8.
-                switch ($listener['entryType']) {
-                    case ListenerFunctionEntry::class:
-                        $ret[] = $listener['listener'];
-                        break;
-                    case ListenerStaticMethodEntry::class:
-                        $ret[] = [$listener['class'], $listener['method']];
-                        break;
-                    case ListenerServiceEntry::class:
-                        $ret[] = function (object $event) use ($listener): void {
-                            $this->container->get($listener['serviceName'])->{$listener['method']}($event);
-                        };
-                        break;
-                    default:
-                        throw new \RuntimeException(sprintf('No such listener type found in compiled container definition: %s', $listener['entryType']));
-                }
+                $ret[] = $listener['callable'];
             }
         }
         return $ret;

--- a/src/CompiledListenerProviderBase.php
+++ b/src/CompiledListenerProviderBase.php
@@ -31,8 +31,9 @@ class CompiledListenerProviderBase implements ListenerProviderInterface
      */
     public function getListenersForEvent(object $event): iterable
     {
-        if (isset($this->optimized[$event::class])) {
-            return $this->optimized[$event::class];
+        // @todo Switch to ::class syntax in PHP 8.
+        if (isset($this->optimized[get_class($event)])) {
+            return $this->optimized[get_class($event)];
         }
 
         $count = count($this->listeners);

--- a/src/ProviderBuilder.php
+++ b/src/ProviderBuilder.php
@@ -32,17 +32,17 @@ class ProviderBuilder implements OrderedProviderInterface, \IteratorAggregate
     /**
      * Pre-specify an event class that should have an optimized listener list built.
      *
-     * @param class-string $event
+     * @param class-string ...$events
      */
-    public function optimizeEvent(string $event): void
+    public function optimizeEvents(string ...$events): void
     {
-        $this->optimizedEvents[] = $event;
+        $this->optimizedEvents = [...$this->optimizedEvents, ...$events];
     }
 
     /**
      * @return array<class-string>
      */
-    public function optimizedEvents(): array
+    public function getOptimizedEvents(): array
     {
         return $this->optimizedEvents;
     }

--- a/src/ProviderBuilder.php
+++ b/src/ProviderBuilder.php
@@ -19,9 +19,29 @@ class ProviderBuilder implements OrderedProviderInterface, \IteratorAggregate
      */
     protected OrderedCollection $listeners;
 
+    /**
+     * @var array<class-string>
+     */
+    protected array $optimizedEvents = [];
+
     public function __construct()
     {
         $this->listeners = new OrderedCollection();
+    }
+
+    /**
+     * Pre-specify an event class that should have an optimized listener list built.
+     *
+     * @param class-string $event
+     */
+    public function optimizeEvent(string $event): void
+    {
+        $this->optimizedEvents[] = $event;
+    }
+
+    public function optimizedEvents(): array
+    {
+        return $this->optimizedEvents;
     }
 
     public function addListener(callable $listener, ?int $priority = null, ?string $id = null, ?string $type = null): string

--- a/src/ProviderBuilder.php
+++ b/src/ProviderBuilder.php
@@ -39,6 +39,9 @@ class ProviderBuilder implements OrderedProviderInterface, \IteratorAggregate
         $this->optimizedEvents[] = $event;
     }
 
+    /**
+     * @return array<class-string>
+     */
     public function optimizedEvents(): array
     {
         return $this->optimizedEvents;

--- a/src/ProviderCompiler.php
+++ b/src/ProviderCompiler.php
@@ -36,6 +36,10 @@ class ProviderCompiler
         fwrite($stream, $this->createClosing());
     }
 
+    /**
+     * @param resource $stream
+     *   A writeable stream to which to write the compiled code.
+     */
     protected function writeMainListenersList(ProviderBuilder $listeners, $stream): void
     {
         fwrite($stream, $this->startMainListenersList());
@@ -49,6 +53,10 @@ class ProviderCompiler
         fwrite($stream, $this->endMainListenersList());
     }
 
+    /**
+     * @param resource $stream
+     *   A writeable stream to which to write the compiled code.
+     */
     protected function writeOptimizedList(ProviderBuilder $listeners, $stream): void
     {
         fwrite($stream, $this->startOptimizedList());

--- a/src/ProviderCompiler.php
+++ b/src/ProviderCompiler.php
@@ -63,7 +63,7 @@ class ProviderCompiler
 
         $listenerDefs = iterator_to_array($listeners, false);
 
-        foreach ($listeners->optimizedEvents() as $event) {
+        foreach ($listeners->getOptimizedEvents() as $event) {
             $ancestors = $this->classAncestors($event);
 
             fwrite($stream, $this->startOptimizedEntry($event));

--- a/src/ProviderCompiler.php
+++ b/src/ProviderCompiler.php
@@ -112,6 +112,7 @@ END;
     {
         return <<<'END'
     ];
+
 END;
     }
 
@@ -134,6 +135,7 @@ use Psr\EventDispatcher\EventInterface;
 
 class {$class} extends CompiledListenerProviderBase
 {
+
 END;
     }
 
@@ -150,6 +152,7 @@ END;
     {
         return <<<'END'
     ];
+
 END;
     }
 
@@ -157,6 +160,7 @@ END;
     {
         return <<<'END'
 }
+
 END;
     }
 }

--- a/tests/CompiledListenerProviderTest.php
+++ b/tests/CompiledListenerProviderTest.php
@@ -155,5 +155,31 @@ class CompiledEventDispatcherTest extends TestCase
         $this->assertEquals('BACD', implode($event->result()));
     }
 
+    public function test_optimize_event(): void
+    {
+        $class = 'OptimizedEventProvider';
+        $namespace = 'Test\\Space';
 
+        $builder = new ProviderBuilder();
+        $container = new MockContainer();
+
+        // Just to make the following lines shorter and easier to read.
+        $ns = '\\Crell\\Tukio\\';
+
+        $builder->addListener("{$ns}event_listener_one", -4, 'id-1');
+        $builder->addListenerBefore('id-1', "{$ns}event_listener_two", 'id-2');
+        $builder->addListenerAfter('id-2', "{$ns}event_listener_three", 'id-3');
+        $builder->addListenerAfter('id-3', "{$ns}event_listener_four");
+
+        $builder->optimizeEvent(CollectingEvent::class);
+
+        $provider = $this->makeProvider($builder, $container, $class, $namespace);
+
+        $event = new CollectingEvent();
+        foreach ($provider->getListenersForEvent($event) as $listener) {
+            $listener($event);
+        }
+
+        $this->assertEquals('BACD', implode($event->result()));
+    }
 }

--- a/tests/CompiledListenerProviderTest.php
+++ b/tests/CompiledListenerProviderTest.php
@@ -171,7 +171,7 @@ class CompiledEventDispatcherTest extends TestCase
         $builder->addListenerAfter('id-2', "{$ns}event_listener_three", 'id-3');
         $builder->addListenerAfter('id-3', "{$ns}event_listener_four");
 
-        $builder->optimizeEvent(CollectingEvent::class);
+        $builder->optimizeEvents(CollectingEvent::class);
 
         $provider = $this->makeProvider($builder, $container, $class, $namespace);
 

--- a/tests/DummyEvent.php
+++ b/tests/DummyEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crell\Tukio;
+
+
+class DummyEvent
+{
+}


### PR DESCRIPTION
## Description

This PR lets the user specify on the `ProviderBuilder` what events it should optimize.  Once we have the class name of those events, we can pre-compute all the listeners that will apply to that event and write out that list directly in the compiled container.  That way, those events become an O(1) array lookup.

It also moves most of the callable-creation logic to compile time, which makes the compiled code both smaller and faster.

## Motivation and context

Because speed.  And an O(1) listener provider is pretty sweet.

## How has this been tested?

I think the benchmarks from my computer show the benefits of this approach adequately.

The memory usage is slightly higher, which I think is attributable to the code size of the generated class.  For that execution time boost, I think it's absolutely worth it.

```
+--------------------------------+----------------------+-----+------+-----+----------+----------+--------+
| benchmark                      | subject              | set | revs | its | mem_peak | mode     | rstdev |
+--------------------------------+----------------------+-----+------+-----+----------+----------+--------+
| CompiledProviderBench          | bench_match_provider |     | 50   | 10  | 3.184mb  | 0.1048ms | ±3.62% |
| OptimizedCompiledProviderBench | bench_match_provider |     | 50   | 10  | 4.555mb  | 0.0003ms | ±4.48% |
| OrderedProviderBench           | bench_match_provider |     | 50   | 10  | 2.022mb  | 0.1443ms | ±2.31% |
+--------------------------------+----------------------+-----+------+-----+----------+----------+--------+
```

The PHPStan checks fail on PHP 7.4 due to the presence of PHP 8 attribute machinery; they don't actually cause a problem because there are checks already to avoid that code path.  Since PHP 7.4 is already unsupported and the next major of Tukio will require PHP 8, I don't care about it.  The tests pass, and that is enough.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
